### PR TITLE
Implement booking form autofill extension

### DIFF
--- a/autofill-extension/README.md
+++ b/autofill-extension/README.md
@@ -1,0 +1,13 @@
+# Flight Booker Autofill Chrome Extension
+
+This extension adds a floating button to booking pages on **Ryanair** and **WizzAir**. Clicking the button fills passenger and contact information with test data.
+
+## Installation
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select this `autofill-extension` folder.
+
+## Usage
+Visit a booking page on `ryanair.com` or `wizzair.com`. A **Fill Passenger Info** button will appear in the bottom-right corner of the page. Clicking it fills the passenger forms with test data. On Ryanair, the script specifically targets fields with `data-ref` attributes used for passenger details and contact information. On WizzAir, it falls back to common field names.
+
+The extension uses placeholder test data that can be modified in `content.js`.

--- a/autofill-extension/content.js
+++ b/autofill-extension/content.js
@@ -1,0 +1,102 @@
+(() => {
+  const passenger = {
+    firstName: 'John',
+    lastName: 'Doe',
+    email: 'john.doe@example.com',
+    phone: '1234567890',
+    dob: '1990-01-01'
+  };
+
+  function setValue(input, value) {
+    if (!input) return;
+    input.focus();
+    input.value = value;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  function fillRyanair() {
+    document
+      .querySelectorAll("ry-input-d[data-ref='pax-details__name'] input")
+      .forEach(i => setValue(i, passenger.firstName));
+    document
+      .querySelectorAll("ry-input-d[data-ref='pax-details__surname'] input")
+      .forEach(i => setValue(i, passenger.lastName));
+    document
+      .querySelectorAll("ry-input-d[data-ref='pax-details__dob'] input")
+      .forEach(i => setValue(i, passenger.dob));
+
+    setValue(
+      document.querySelector(
+        "ry-input-d[data-ref='contact-details__email'] input, input[type='email']"
+      ),
+      passenger.email
+    );
+    setValue(
+      document.querySelector(
+        "ry-input-d[data-ref='contact-details__phone'] input, input[type='tel']"
+      ),
+      passenger.phone
+    );
+  }
+
+  function fillWizzAir() {
+    setValue(document.querySelector("input[name*='firstName']"), passenger.firstName);
+    setValue(document.querySelector("input[name*='lastName']"), passenger.lastName);
+    setValue(document.querySelector("input[type='email']"), passenger.email);
+    setValue(document.querySelector("input[type='tel']"), passenger.phone);
+  }
+
+  function fillGeneric() {
+    const selectors = [
+      ["input[name*='first']", "input[placeholder*='First']"],
+      ["input[name*='last']", "input[placeholder*='Last']"],
+      ["input[type='email']", "input[name*='mail']"],
+      ["input[type='tel']", "input[name*='phone']"]
+    ];
+    const values = [passenger.firstName, passenger.lastName, passenger.email, passenger.phone];
+    selectors.forEach((sels, idx) => {
+      for (const sel of sels) {
+        const el = document.querySelector(sel);
+        if (el) {
+          setValue(el, values[idx]);
+          break;
+        }
+      }
+    });
+  }
+
+  function fillFields() {
+    if (location.hostname.includes('ryanair.com')) {
+      fillRyanair();
+    } else if (location.hostname.includes('wizzair.com')) {
+      fillWizzAir();
+    } else {
+      fillGeneric();
+    }
+  }
+
+  function createButton() {
+    const btn = document.createElement('button');
+    btn.textContent = 'Fill Passenger Info';
+    Object.assign(btn.style, {
+      position: 'fixed',
+      bottom: '20px',
+      right: '20px',
+      zIndex: 9999,
+      padding: '10px 15px',
+      background: '#00aaff',
+      color: '#fff',
+      border: 'none',
+      borderRadius: '4px',
+      cursor: 'pointer'
+    });
+    btn.addEventListener('click', fillFields);
+    document.body.appendChild(btn);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', createButton);
+  } else {
+    createButton();
+  }
+})();

--- a/autofill-extension/manifest.json
+++ b/autofill-extension/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "Flight Booker Autofill",
+  "description": "Autofills passenger and contact info on Ryanair and WizzAir booking pages.",
+  "version": "1.0",
+  "permissions": ["activeTab", "scripting"],
+  "content_scripts": [
+    {
+      "matches": ["*://*.ryanair.com/*", "*://*.wizzair.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Chrome extension that provides a floating button on Ryanair and WizzAir booking pages
- clicking the button fills first name, last name, email, and phone with test data
- document installation and usage
- refine selectors for Ryanair fields and add fallback logic

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_688a0f17ddfc8329b93735b6b9101ee3