### PR TITLE
Restrict generic autofill button to specific sites

### DIFF
--- a/autofill-extension/README.md
+++ b/autofill-extension/README.md
@@ -16,6 +16,13 @@ Five sample passengers are defined (three adults and two children). When the
 forms with these unique details. Contact information is taken from the first
 adult passenger.
 
+## Restricting the Generic Button
+The file `generic.js` injects a floating button on any page that the extension
+is loaded on. To limit this behaviour to specific sites, edit the
+`allowedDomains` array at the top of `generic.js` and include the host names you
+want to support. If the current page's hostname does not match any value in
+`allowedDomains`, no button is shown.
+
 The script also checks for fields with full name attributes like
 `form.passengers.ADT-0.name` and fills them directly, dispatching a `change`
 event after setting the value.

--- a/autofill-extension/generic.js
+++ b/autofill-extension/generic.js
@@ -1,4 +1,10 @@
 (() => {
+  // Domains that should display the autofill button. Update this list as needed.
+  const allowedDomains = ['example.com'];
+  if (!allowedDomains.some(domain => location.hostname.includes(domain))) {
+    return;
+  }
+
   const { passengers, mainPassenger, setValue, setValueByName, setDropdown, setGender, createButton } = window.autofillCommon;
 
   function fillGeneric() {


### PR DESCRIPTION
## Summary
- limit the generic script so the button only appears on configured domains
- document how to configure the allowed domains

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688a37be42088329af8af21f054cfef0