### PR TITLE
Remove icons from manifest

### DIFF
--- a/autofill-extension/manifest.json
+++ b/autofill-extension/manifest.json
@@ -3,19 +3,8 @@
   "name": "Flight Booker Autofill",
   "description": "Autofills passenger and contact info on booking pages.",
   "version": "1.0",
-  "icons": {
-    "16": "icons/icon16.png",
-    "48": "icons/icon48.png",
-    "128": "icons/icon128.png"
-  },
   "action": {
-    "default_title": "Autofill",
-    "default_icon": {
-      "16": "icons/icon16.png",
-      "32": "icons/icon32.png",
-      "48": "icons/icon48.png",
-      "128": "icons/icon128.png"
-    }
+    "default_title": "Autofill"
   },
   "permissions": ["activeTab", "scripting"],
   "content_scripts": [


### PR DESCRIPTION
## Summary
- remove icon references from the Chrome extension manifest

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688a69c9eeb0832994f45a3aaae2f75f