### PR TITLE
Support contact array in API response

### DIFF
--- a/autofill-extension/README.md
+++ b/autofill-extension/README.md
@@ -8,13 +8,13 @@ This extension adds a floating button to booking pages on **Ryanair**, **WizzAir
 3. Click **Load unpacked** and select this `autofill-extension` folder.
 
 ## Usage
-Visit a booking page on `ryanair.com`, `wizzair.com` or `hotelston.com`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details and contact information. On WizzAir and Hotelston it falls back to common field names. The Hotelston script intentionally leaves the contact fields blank.
+Visit a booking page on `ryanair.com`, `wizzair.com` or `hotelston.com`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details and contact information. Contact details are populated from the `contact` array in the booking API response when present. On WizzAir and Hotelston it falls back to common field names. The Hotelston script intentionally leaves the contact fields blank.
 
 The extension uses placeholder test data that can be modified in `common.js`.
 Five sample passengers are defined (three adults and two children). When the
 **Fill Passenger Info** button is clicked, the script fills up to five passenger
 forms with these unique details. Contact information is taken from the first
-adult passenger.
+adult passenger unless the API response includes a `contact` array.
 
 ## Restricting the Generic Button
 The file `generic.js` injects a floating button on any page that the extension

--- a/autofill-extension/common.js
+++ b/autofill-extension/common.js
@@ -125,6 +125,36 @@
     if (value != null) setDropdown(select, value);
   }
 
+  function getContactInfo(data) {
+    const result = { email: data?.email || null, phone: data?.phone || null };
+    const contacts = Array.isArray(data?.contact)
+      ? data.contact
+      : Array.isArray(data?.contacts)
+      ? data.contacts
+      : null;
+    if (contacts) {
+      for (const c of contacts) {
+        const type = (c.type || '').toLowerCase();
+        if (!result.email) {
+          if (c.email) {
+            result.email = c.email;
+          } else if (type.includes('mail') && c.value) {
+            result.email = c.value;
+          }
+        }
+        if (!result.phone) {
+          if (c.phone) {
+            result.phone = c.phone;
+          } else if (/phone|tel/.test(type) && c.value) {
+            result.phone = c.value;
+          }
+        }
+        if (result.email && result.phone) break;
+      }
+    }
+    return result;
+  }
+
   function createButton(onClick) {
     const container = document.createElement('div');
     Object.assign(container.style, {
@@ -188,6 +218,7 @@
     setDropdown,
     getMaleValue,
     setGender,
+    getContactInfo,
     createButton
   };
 })();

--- a/autofill-extension/generic.js
+++ b/autofill-extension/generic.js
@@ -5,10 +5,20 @@
     return;
   }
 
-  const { passengers, mainPassenger, setValue, setValueByName, setDropdown, setGender, createButton } = window.autofillCommon;
+  const {
+    passengers,
+    mainPassenger,
+    setValue,
+    setValueByName,
+    setDropdown,
+    setGender,
+    getContactInfo,
+    createButton
+  } = window.autofillCommon;
 
   function fillGeneric(data) {
     const pax = data && data.passports ? data.passports : passengers;
+    const contact = getContactInfo(data || {});
 
     pax.forEach((p, idx) => {
       const first = p.first_name || p.firstName;
@@ -16,8 +26,8 @@
       setValueByName(`form.passengers.ADT-${idx}.name`, first);
       setValueByName(`form.passengers.ADT-${idx}.surname`, last);
       if (idx === 0) {
-        const email = data?.email || p.email || mainPassenger.email;
-        const phone = data?.phone || p.phone || mainPassenger.phone;
+        const email = contact.email || p.email || mainPassenger.email;
+        const phone = contact.phone || p.phone || mainPassenger.phone;
         setValueByName(`form.passengers.ADT-${idx}.email`, email);
         setValueByName(`form.passengers.ADT-${idx}.phone`, phone);
       }
@@ -34,9 +44,9 @@
       setValue(el, last);
     });
     const emailInput = document.querySelector("input[type='email']");
-    if (emailInput) setValue(emailInput, data?.email || mainPassenger.email);
+    if (emailInput) setValue(emailInput, contact.email || mainPassenger.email);
     const phoneInput = document.querySelector("input[type='tel']");
-    if (phoneInput) setValue(phoneInput, data?.phone || mainPassenger.phone);
+    if (phoneInput) setValue(phoneInput, contact.phone || mainPassenger.phone);
 
     const titleField = document.querySelector("select[name*='title']");
     if (titleField) setDropdown(titleField, 'MR');

--- a/autofill-extension/ryanair.js
+++ b/autofill-extension/ryanair.js
@@ -5,6 +5,7 @@
     setValue,
     setDropdown,
     setGender,
+    getContactInfo,
     createButton
   } = window.autofillCommon;
 
@@ -22,6 +23,7 @@
 
   function fillRyanair(data) {
     const pax = data && data.passports ? data.passports : passengers;
+    const contact = getContactInfo(data || {});
     setRyanairTitles(pax[0]?.sex || 'MR');
     setRyanairGender();
     const firstInputs = document.querySelectorAll(
@@ -50,13 +52,13 @@
       document.querySelector(
         "ry-input-d[data-ref='contact-details__email'] input, input[type='email']"
       ),
-      data?.email || mainPassenger.email
+      contact.email || mainPassenger.email
     );
     setValue(
       document.querySelector(
         "ry-input-d[data-ref='contact-details__phone'] input, input[type='tel']"
       ),
-      data?.phone || mainPassenger.phone
+      contact.phone || mainPassenger.phone
     );
   }
 

--- a/autofill-extension/wizzair.js
+++ b/autofill-extension/wizzair.js
@@ -1,8 +1,17 @@
 (() => {
-  const { passengers, mainPassenger, setValue, setDropdown, setGender, createButton } = window.autofillCommon;
+  const {
+    passengers,
+    mainPassenger,
+    setValue,
+    setDropdown,
+    setGender,
+    getContactInfo,
+    createButton
+  } = window.autofillCommon;
 
   function fillWizzAir(data) {
     const pax = data && data.passports ? data.passports : passengers;
+    const contact = getContactInfo(data || {});
     setDropdown(
       document.querySelector("select[name*='title'], select[id*='title']"),
       pax[0]?.sex || 'MR'
@@ -18,11 +27,11 @@
       setValue(lastInput, pax[0] ? (pax[0].last_name || pax[0].lastName) : passengers[0].lastName);
     setValue(
       document.querySelector("input[type='email']"),
-      data?.email || mainPassenger.email
+      contact.email || mainPassenger.email
     );
     setValue(
       document.querySelector("input[type='tel']"),
-      data?.phone || mainPassenger.phone
+      contact.phone || mainPassenger.phone
     );
   }
 


### PR DESCRIPTION
## Summary
- add getContactInfo helper to parse contact details from API responses
- use getContactInfo in generic, WizzAir and Ryanair scripts
- mention contact array in documentation

## Testing
- `node --check autofill-extension/common.js`
- `node --check autofill-extension/generic.js`
- `node --check autofill-extension/wizzair.js`
- `node --check autofill-extension/ryanair.js`
- `node --check autofill-extension/hotelston.js`
- `node --check autofill-extension/background.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688ab7fe765483299ec00060e77731ee