### PR TITLE
Add dedicated contact info filling

### DIFF
--- a/autofill-extension/README.md
+++ b/autofill-extension/README.md
@@ -8,13 +8,14 @@ This extension adds a floating button to booking pages on **Ryanair**, **WizzAir
 3. Click **Load unpacked** and select this `autofill-extension` folder.
 
 ## Usage
-Visit a booking page on `ryanair.com`, `wizzair.com` or `hotelston.com`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details and contact information. Contact details are populated from the `contact` array in the booking API response when present. On WizzAir and Hotelston it falls back to common field names. The Hotelston script intentionally leaves the contact fields blank.
+Visit a booking page on `ryanair.com`, `wizzair.com` or `hotelston.com`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details. Contact sections identified by headings like *Контактное лицо* are filled only with contact information from the booking data. On WizzAir and Hotelston the script falls back to common field names. The Hotelston script intentionally leaves the contact fields blank.
 
 The extension uses placeholder test data that can be modified in `common.js`.
 Five sample passengers are defined (three adults and two children). When the
 **Fill Passenger Info** button is clicked, the script fills up to five passenger
-forms with these unique details. Contact information is taken from the first
-adult passenger unless the API response includes a `contact` array.
+forms with these unique details. Contact information is sourced from the
+`contact` block of the booking data when available or from the sample contact
+record defined in `common.js`.
 
 ## Restricting the Generic Button
 The file `generic.js` injects a floating button on any page that the extension

--- a/autofill-extension/common.js
+++ b/autofill-extension/common.js
@@ -47,6 +47,13 @@
     }
   ];
   const mainPassenger = passengers[0];
+  const mainContact = {
+    firstName: 'Test',
+    lastName: 'Contact',
+    email: 'contact@example.com',
+    phone: '5555555555',
+    title: 'MR'
+  };
 
   function setValue(input, value) {
     if (!input) return;
@@ -126,7 +133,13 @@
   }
 
   function getContactInfo(data) {
-    const result = { email: data?.email || null, phone: data?.phone || null };
+    const result = {
+      title: data?.title || null,
+      firstName: data?.first_name || data?.firstName || null,
+      lastName: data?.last_name || data?.lastName || null,
+      email: data?.email || null,
+      phone: data?.phone || null
+    };
     const contacts = Array.isArray(data?.contact)
       ? data.contact
       : Array.isArray(data?.contacts)
@@ -135,6 +148,9 @@
     if (contacts) {
       for (const c of contacts) {
         const type = (c.type || '').toLowerCase();
+        if (!result.firstName) result.firstName = c.first_name || c.firstName || null;
+        if (!result.lastName) result.lastName = c.last_name || c.lastName || null;
+        if (!result.title) result.title = c.title || null;
         if (!result.email) {
           if (c.email) {
             result.email = c.email;
@@ -149,9 +165,14 @@
             result.phone = c.value;
           }
         }
-        if (result.email && result.phone) break;
+        if (result.email && result.phone && result.firstName && result.lastName && result.title) break;
       }
     }
+    if (!result.firstName) result.firstName = mainContact.firstName;
+    if (!result.lastName) result.lastName = mainContact.lastName;
+    if (!result.email) result.email = mainContact.email;
+    if (!result.phone) result.phone = mainContact.phone;
+    if (!result.title) result.title = mainContact.title;
     return result;
   }
 
@@ -260,6 +281,7 @@
   window.autofillCommon = {
     passengers,
     mainPassenger,
+    mainContact,
     setValue,
     setValueByName,
     setDropdown,

--- a/autofill-extension/generic.js
+++ b/autofill-extension/generic.js
@@ -16,9 +16,36 @@
     createButton
   } = window.autofillCommon;
 
+  function findContactSection() {
+    const headings = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    for (const h of headings) {
+      const txt = h.textContent || '';
+      if (/контакт/i.test(txt) || /contact/i.test(txt)) {
+        return h.closest('form') || h.parentElement;
+      }
+    }
+    return null;
+  }
+
+  function fillContactSection(contact, section) {
+    if (!section) return;
+    setDropdown(section.querySelector('select'), contact.title || 'MR');
+    setValue(
+      section.querySelector("input[name='firstname'], input[name*='first']"),
+      contact.firstName
+    );
+    setValue(
+      section.querySelector("input[name='lastname'], input[name*='last']"),
+      contact.lastName
+    );
+    setValue(section.querySelector("input[type='email']"), contact.email);
+    setValue(section.querySelector("input[type='tel']"), contact.phone);
+  }
+
   function fillGeneric(data) {
     const pax = data && data.passports ? data.passports : passengers;
     const contact = getContactInfo(data || {});
+    const contactSection = findContactSection();
 
     pax.forEach((p, idx) => {
       const first = p.first_name || p.firstName;
@@ -26,27 +53,33 @@
       setValueByName(`form.passengers.ADT-${idx}.name`, first);
       setValueByName(`form.passengers.ADT-${idx}.surname`, last);
       if (idx === 0) {
-        const email = contact.email || p.email || mainPassenger.email;
-        const phone = contact.phone || p.phone || mainPassenger.phone;
-        setValueByName(`form.passengers.ADT-${idx}.email`, email);
-        setValueByName(`form.passengers.ADT-${idx}.phone`, phone);
+        setValueByName(`form.passengers.ADT-${idx}.email`, contact.email);
+        setValueByName(`form.passengers.ADT-${idx}.phone`, contact.phone);
       }
     });
 
     const firstInputs = document.querySelectorAll("input[name*='first']");
     firstInputs.forEach((el, idx) => {
+      if (contactSection && contactSection.contains(el)) return;
       const first = pax[idx] ? (pax[idx].first_name || pax[idx].firstName) : (pax[0].first_name || pax[0].firstName);
       setValue(el, first);
     });
     const lastInputs = document.querySelectorAll("input[name*='last']");
     lastInputs.forEach((el, idx) => {
+      if (contactSection && contactSection.contains(el)) return;
       const last = pax[idx] ? (pax[idx].last_name || pax[idx].lastName) : (pax[0].last_name || pax[0].lastName);
       setValue(el, last);
     });
     const emailInput = document.querySelector("input[type='email']");
-    if (emailInput) setValue(emailInput, contact.email || mainPassenger.email);
+    if (emailInput && (!contactSection || !contactSection.contains(emailInput))) {
+      setValue(emailInput, contact.email);
+    }
     const phoneInput = document.querySelector("input[type='tel']");
-    if (phoneInput) setValue(phoneInput, contact.phone || mainPassenger.phone);
+    if (phoneInput && (!contactSection || !contactSection.contains(phoneInput))) {
+      setValue(phoneInput, contact.phone);
+    }
+
+    fillContactSection(contact, contactSection);
 
     const titleField = document.querySelector("select[name*='title']");
     if (titleField) setDropdown(titleField, 'MR');

--- a/autofill-extension/ryanair.js
+++ b/autofill-extension/ryanair.js
@@ -52,13 +52,13 @@
       document.querySelector(
         "ry-input-d[data-ref='contact-details__email'] input, input[type='email']"
       ),
-      contact.email || mainPassenger.email
+      contact.email
     );
     setValue(
       document.querySelector(
         "ry-input-d[data-ref='contact-details__phone'] input, input[type='tel']"
       ),
-      contact.phone || mainPassenger.phone
+      contact.phone
     );
   }
 

--- a/autofill-extension/wizzair.js
+++ b/autofill-extension/wizzair.js
@@ -25,14 +25,8 @@
     const lastInput = document.querySelector("input[name*='lastName']");
     if (lastInput)
       setValue(lastInput, pax[0] ? (pax[0].last_name || pax[0].lastName) : passengers[0].lastName);
-    setValue(
-      document.querySelector("input[type='email']"),
-      contact.email || mainPassenger.email
-    );
-    setValue(
-      document.querySelector("input[type='tel']"),
-      contact.phone || mainPassenger.phone
-    );
+    setValue(document.querySelector("input[type='email']"), contact.email);
+    setValue(document.querySelector("input[type='tel']"), contact.phone);
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- introduce sample contact person data in `common.js`
- extend `getContactInfo` to return names and title and fall back to the new sample contact
- detect and fill contact form sections only with contact data in `generic.js`
- remove passenger fallbacks for contact fields on Ryanair and WizzAir
- document the contact form behaviour in `README`

## Testing
- `npm --version`
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_688abb1f0f508329a0e61ca1f5b13485