### PR TITLE
Fix contact info extraction

### DIFF
--- a/autofill-extension/common.js
+++ b/autofill-extension/common.js
@@ -144,6 +144,8 @@
       ? data.contact
       : Array.isArray(data?.contacts)
       ? data.contacts
+      : data?.contact && typeof data.contact === 'object'
+      ? [data.contact]
       : null;
     if (contacts) {
       for (const c of contacts) {


### PR DESCRIPTION
## Summary
- handle contact object for contact details when populating forms

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688b5acc31c48329adbefa7f37b15142