### PR TITLE
Update Itravex autofill to set reference

### DIFF
--- a/autofill-extension/itravex.js
+++ b/autofill-extension/itravex.js
@@ -9,6 +9,9 @@
   function fillItravex(data) {
     const pax = data && data.passports ? data.passports : passengers;
     const contact = getContactInfo(data || {});
+    const orderId =
+      data?.order_id || data?.orderId || data?.id || data?.booking_id || '';
+    setValue(document.getElementById('reference'), orderId);
 
     pax.forEach((p, idx) => {
       const first = p.first_name || p.firstName;


### PR DESCRIPTION
## Summary
- set the order id into the `reference` field for Itravex booking forms

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688b60d1a2f88329a37e0acd5422a69e