### PR TITLE
Set font size for info box

### DIFF
--- a/autofill-extension/common.js
+++ b/autofill-extension/common.js
@@ -207,6 +207,7 @@
       border: '1px solid #ccc',
       padding: '10px',
       borderRadius: '4px',
+      fontSize: '11px',
       maxWidth: '400px',
       overflow: 'auto',
       display: 'none'


### PR DESCRIPTION
## Summary
- add `fontSize` style to the info box so text is 11px

## Testing
- `node --check autofill-extension/common.js`


------
https://chatgpt.com/codex/tasks/task_b_688b6aec35ec8329a60dca9050053d5b