### PR TITLE
Update hotelbeds autofill to ignore passenger fields

### DIFF
--- a/autofill-extension/hotelbeds.js
+++ b/autofill-extension/hotelbeds.js
@@ -7,6 +7,28 @@
     createButton
   } = window.autofillCommon;
 
+  const skipContainers = [
+    '.hotel__body__customers__items',
+    '.hotel__body__customers__item'
+  ];
+
+  function selectOutside(selector) {
+    const elements = document.querySelectorAll(selector);
+    for (const el of elements) {
+      let insideSkip = false;
+      for (const container of skipContainers) {
+        if (el.closest(container)) {
+          insideSkip = true;
+          break;
+        }
+      }
+      if (!insideSkip) {
+        return el;
+      }
+    }
+    return null;
+  }
+
   function splitPhone(phone) {
     const digits = String(phone || '').replace(/\D+/g, '');
     const code = digits.slice(0, 3);
@@ -20,35 +42,35 @@
     const first = pax[0] || passengers[0];
 
     setValue(
-      document.querySelector("input[formcontrolname='name']"),
+      selectOutside("input[formcontrolname='name']"),
       first.first_name || first.firstName
     );
     setValue(
-      document.querySelector("input[formcontrolname='surname']"),
+      selectOutside("input[formcontrolname='surname']"),
       first.last_name || first.lastName
     );
 
     const { code, number } = splitPhone(contact.phone);
     setDropdown(
-      document.querySelector("[formcontrolname='countryCode']"),
+      selectOutside("[formcontrolname='countryCode']"),
       code
     );
     setValue(
-      document.querySelector("input[formcontrolname='phoneNumber']"),
+      selectOutside("input[formcontrolname='phoneNumber']"),
       number
     );
-    const phoneInput = document.querySelector("input[formcontrolname='phone']");
+    const phoneInput = selectOutside("input[formcontrolname='phone']");
     if (phoneInput) setValue(phoneInput, code + number);
 
     setValue(
-      document.querySelector("input[formcontrolname='email']"),
+      selectOutside("input[formcontrolname='email']"),
       contact.email
     );
 
     const orderId =
       data?.order_id || data?.orderId || data?.id || data?.booking_id || '';
     setValue(
-      document.querySelector("input[formcontrolname='clientReference']"),
+      selectOutside("input[formcontrolname='clientReference']"),
       orderId
     );
   }


### PR DESCRIPTION
## Summary
- skip customer item containers when picking inputs for Hotelbeds autofill

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_688b7089b990832986132f9ca18e1847