### PR TITLE
Fix hotelbeds container selector

### DIFF
--- a/autofill-extension/hotelbeds.js
+++ b/autofill-extension/hotelbeds.js
@@ -7,12 +7,13 @@
     createButton
   } = window.autofillCommon;
 
-  const skipContainer = '.hotel__body__customers__items';
+  const skipContainerSelector = '.hotel__body__customers__items';
 
   function selectOutside(selector) {
+    const skipContainer = document.querySelector(skipContainerSelector);
     const elements = document.querySelectorAll(selector);
     for (const el of elements) {
-      if (!el.closest(skipContainer)) {
+      if (!skipContainer || !skipContainer.contains(el)) {
         return el;
       }
     }


### PR DESCRIPTION
## Summary
- avoid autofill for contact items nested inside `.hotel__body__customers__items` container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688b739c37d0832987833c7ca0ca0013