### PR TITLE
Add W2M DMC autofill support

### DIFF
--- a/autofill-extension/README.md
+++ b/autofill-extension/README.md
@@ -1,6 +1,6 @@
 # Flight Booker Autofill Chrome Extension
 
-This extension adds a floating button to booking pages on **Ryanair**, **WizzAir**, **Hotelston** and **Itravex**. Clicking the button fills passenger data with test information. Contact details are automatically populated on these sites when a section titled *Контактное лицо* or similar is found.
+This extension adds a floating button to booking pages on **Ryanair**, **WizzAir**, **Hotelston**, **Itravex** and **W2M DMC**. Clicking the button fills passenger data with test information. Contact details are automatically populated on these sites when a section titled *Контактное лицо* or similar is found.
 
 ## Installation
 1. Open Chrome and navigate to `chrome://extensions`.
@@ -8,7 +8,7 @@ This extension adds a floating button to booking pages on **Ryanair**, **WizzAir
 3. Click **Load unpacked** and select this `autofill-extension` folder.
 
 ## Usage
-Visit a booking page on `ryanair.com`, `wizzair.com`, `hotelston.com` or `b2bdirect.itravex.es`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details. Contact sections identified by headings like *Контактное лицо* are filled only with contact information from the booking data. On WizzAir, Hotelston and Itravex the script falls back to common field names and now also completes the contact form when detected. Hotelston pages that include a form with the `booking-info-search-form` id are also supported, automatically filling each traveller block and the contact section.
+Visit a booking page on `ryanair.com`, `wizzair.com`, `hotelston.com` or `b2bdirect.itravex.es` or `b2dmc.w2m.travel`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details. Contact sections identified by headings like *Контактное лицо* are filled only with contact information from the booking data. On WizzAir, Hotelston and Itravex the script falls back to common field names and now also completes the contact form when detected. Hotelston pages that include a form with the `booking-info-search-form` id are also supported, automatically filling each traveller block and the contact section.
 
 The extension uses placeholder test data that can be modified in `common.js`.
 Five sample passengers are defined (three adults and two children). When the

--- a/autofill-extension/manifest.json
+++ b/autofill-extension/manifest.json
@@ -74,6 +74,17 @@
     },
     {
       "matches": [
+        "*://b2dmc.w2m.travel/*"
+      ],
+      "js": [
+        "lib/jquery.min.js",
+        "common.js",
+        "w2m.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": [
         "*://bedbank.viajesolympia.com/*"
       ],
       "js": [

--- a/autofill-extension/w2m.js
+++ b/autofill-extension/w2m.js
@@ -1,0 +1,34 @@
+(() => {
+  const {
+    passengers,
+    mainPassenger,
+    setValue,
+    createButton
+  } = window.autofillCommon;
+
+  function fillW2M(data) {
+    const pax = data && data.passports ? data.passports : passengers;
+    const first = pax[0] || mainPassenger;
+    const orderId =
+      data?.order_id || data?.orderId || data?.id || data?.booking_id || '';
+
+    const row = document.querySelector('.js-pax-row:not(.hidden)');
+    const nameInput =
+      row?.querySelector("input[name='pax-name']") ||
+      document.querySelector("input[name='pax-name']");
+    const surnameInput =
+      row?.querySelector("input[name='pax-surname']") ||
+      document.querySelector("input[name='pax-surname']");
+
+    setValue(nameInput, first.first_name || first.firstName);
+    setValue(surnameInput, first.last_name || first.lastName);
+
+    setValue(document.getElementById('booking_reference'), orderId);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => createButton(fillW2M));
+  } else {
+    createButton(fillW2M);
+  }
+})();


### PR DESCRIPTION
## Summary
- include W2M DMC in supported sites
- create `w2m.js` script to autofill main passenger name and agency reference
- document new site support in README

## Testing
- `./package.sh`

------
https://chatgpt.com/codex/tasks/task_b_688d262c86c88329a5f78d87fd32d0e6