### PR TITLE
Add Chartershop autofill support

### DIFF
--- a/autofill-extension/README.md
+++ b/autofill-extension/README.md
@@ -1,6 +1,6 @@
 # Flight Booker Autofill Chrome Extension
 
-This extension adds a floating button to booking pages on **Ryanair**, **WizzAir**, **Hotelston**, **Itravex**, **W2M DMC** and **Kiwi.com**. Clicking the button fills passenger data with test information. Contact details are automatically populated on these sites when a section titled *Контактное лицо* or similar is found.
+This extension adds a floating button to booking pages on **Ryanair**, **WizzAir**, **Hotelston**, **Itravex**, **W2M DMC**, **Chartershop** and **Kiwi.com**. Clicking the button fills passenger data with test information. Contact details are automatically populated on these sites when a section titled *Контактное лицо* or similar is found.
 
 ## Installation
 1. Open Chrome and navigate to `chrome://extensions`.
@@ -8,7 +8,7 @@ This extension adds a floating button to booking pages on **Ryanair**, **WizzAir
 3. Click **Load unpacked** and select this `autofill-extension` folder.
 
 ## Usage
-Visit a booking page on `ryanair.com`, `wizzair.com`, `hotelston.com`, `b2bdirect.itravex.es`, `b2dmc.w2m.travel` or `kiwi.com`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details. Contact sections identified by headings like *Контактное лицо* are filled only with contact information from the booking data. On WizzAir, Hotelston and Itravex the script falls back to common field names and now also completes the contact form when detected. Hotelston pages that include a form with the `booking-info-search-form` id are also supported, automatically filling each traveller block and the contact section.
+Visit a booking page on `ryanair.com`, `wizzair.com`, `hotelston.com`, `b2bdirect.itravex.es`, `b2dmc.w2m.travel`, `chartershop.com.ua`, `chartershop.eu` or `kiwi.com`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details. Contact sections identified by headings like *Контактное лицо* are filled only with contact information from the booking data. On WizzAir, Hotelston and Itravex the script falls back to common field names and now also completes the contact form when detected. Hotelston pages that include a form with the `booking-info-search-form` id are also supported, automatically filling each traveller block and the contact section.
 
 The extension uses placeholder test data that can be modified in `common.js`.
 Five sample passengers are defined (three adults and two children). When the

--- a/autofill-extension/chartershop.js
+++ b/autofill-extension/chartershop.js
@@ -1,0 +1,49 @@
+(() => {
+  const {
+    passengers,
+    setValue,
+    setDropdown,
+    createButton
+  } = window.autofillCommon;
+
+  function formatDate(value) {
+    if (!value) return '';
+    const m = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (m) return `${m[3]}.${m[2]}.${m[1]}`;
+    const m2 = value.match(/^(\d{2})[./-](\d{2})[./-](\d{4})/);
+    if (m2) return `${m2[1]}.${m2[2]}.${m2[3]}`;
+    return value;
+  }
+
+  function fillChartershop(data) {
+    const pax = data && data.passports ? data.passports : passengers;
+    const forms = document.querySelectorAll('.booking-passenger');
+    pax.forEach((p, idx) => {
+      const form = forms[idx];
+      if (!form) return;
+      const gender = (p.gender || p.sex || '').toUpperCase();
+      const genderVal = /FEMALE|F/.test(gender) ? '1' : '0';
+      setDropdown(form.querySelector('.passenger-sex'), genderVal);
+      setValue(form.querySelector('.passenger-lname'), p.last_name || p.lastName || '');
+      setValue(form.querySelector('.passenger-fname'), p.first_name || p.firstName || '');
+      const dob = p.birthday || p.dob;
+      setValue(form.querySelector('.passenger-birth'), formatDate(dob));
+      const nationality = (p.nationality || p.citizenship || 'UA').toUpperCase();
+      setDropdown(form.querySelector('.passenger-citizenship'), nationality);
+      const seria = p.passport_seria || p.passportSeries || p.series || p.passport_series || p.seria || '';
+      setValue(form.querySelector('.passport-seria'), seria);
+      const number = p.passport_number || p.passportNumber || p.number || '';
+      setValue(form.querySelector('.passport-number'), number);
+      const issue = p.passport_issue || p.passportIssue || p.issue_date || p.issueDate || '';
+      setValue(form.querySelector('.passport-from'), formatDate(issue));
+      const expiry = p.passport_expiry || p.passportExpiry || p.expiry_date || p.expiry || '';
+      setValue(form.querySelector('.passport-to'), formatDate(expiry));
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => createButton(fillChartershop));
+  } else {
+    createButton(fillChartershop);
+  }
+})();

--- a/autofill-extension/manifest.json
+++ b/autofill-extension/manifest.json
@@ -107,13 +107,27 @@
     },
     {
       "matches": [
+        "*://*.chartershop.com.ua/*",
+        "*://*.chartershop.eu/*"
+      ],
+      "js": [
+        "lib/jquery.min.js",
+        "common.js",
+        "chartershop.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": [
         "<all_urls>"
       ],
       "exclude_matches": [
         "*://*.ryanair.com/*",
         "*://*.wizzair.com/*",
         "*://*.hotelston.com/*",
-        "*://app.hotelbeds.com/*"
+        "*://app.hotelbeds.com/*",
+        "*://*.chartershop.com.ua/*",
+        "*://*.chartershop.eu/*"
       ],
       "js": [
         "lib/jquery.min.js",


### PR DESCRIPTION
## Summary
- add chartershop passenger data autofill script
- document Chartershop support and update manifest

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ab037d02b48329a117a7a0bc2aa09f