### PR TITLE
fix: destroy selectBox without jQuery

### DIFF
--- a/autofill-extension/luxurytraveldmc.js
+++ b/autofill-extension/luxurytraveldmc.js
@@ -1,4 +1,4 @@
-((jQuery) => {
+(() => {
   const {
     passengers,
     setValue,
@@ -7,8 +7,18 @@
     createButton
   } = window.autofillCommon;
 
+  function destroySelectBoxes() {
+    document.querySelectorAll('select.selectBox').forEach(select => {
+      const prev = select.previousElementSibling;
+      if (prev && prev.classList && prev.classList.contains('selectBox')) {
+        prev.remove();
+      }
+      select.style.display = '';
+    });
+  }
+
   function fillLuxuryTravel(data) {
-    jQuery('.selectBox').selectBox('destroy');
+    destroySelectBoxes();
     const pax = data && data.passports ? data.passports : passengers;
     const contact = getContactInfo(data || {});
 
@@ -44,4 +54,4 @@
   } else {
     createButton(fillLuxuryTravel);
   }
-})(jQuery);
+})();


### PR DESCRIPTION
## Summary
- remove jQuery dependency in LuxuryTravel DMC script
- manually clean up `.selectBox` plugin wrappers before autofill

## Testing
- `./package.sh`

------
https://chatgpt.com/codex/tasks/task_b_68adc478c0808329a1a0e0ed84f5f75e