### PR TITLE
Add TBO Hotels autofill support

### DIFF
--- a/autofill-extension/README.md
+++ b/autofill-extension/README.md
@@ -1,7 +1,7 @@
 # Flight Booker Autofill Chrome Extension
 
 
-This extension adds a floating button to booking pages on **Ryanair**, **WizzAir**, **Hotelston**, **Itravex**, **W2M DMC**, **Chartershop**, **Kiwi.com** and **LuxuryTravelDMC**. Clicking the button fills passenger data with test information. Contact details are automatically populated on these sites when a section titled *Контактное лицо* or similar is found.
+This extension adds a floating button to booking pages on **Ryanair**, **WizzAir**, **Hotelston**, **Itravex**, **W2M DMC**, **Chartershop**, **Kiwi.com**, **LuxuryTravelDMC**, and **TBO Hotels**. Clicking the button fills passenger data with test information. Contact details are automatically populated on these sites when a section titled *Контактное лицо* or similar is found.
 
 
 ## Installation
@@ -11,7 +11,7 @@ This extension adds a floating button to booking pages on **Ryanair**, **WizzAir
 
 ## Usage
 
-Visit a booking page on `ryanair.com`, `wizzair.com`, `hotelston.com`, `b2bdirect.itravex.es`, `b2dmc.w2m.travel`, `chartershop.com.ua`, `chartershop.eu`, `kiwi.com` or `luxurytraveldmc.com`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details. Contact sections identified by headings like *Контактное лицо* are filled only with contact information from the booking data. On WizzAir, Hotelston and Itravex the script falls back to common field names and now also completes the contact form when detected. Hotelston pages that include a form with the `booking-info-search-form` id are also supported, automatically filling each traveller block and the contact section.
+Visit a booking page on `ryanair.com`, `wizzair.com`, `hotelston.com`, `b2bdirect.itravex.es`, `b2dmc.w2m.travel`, `chartershop.com.ua`, `chartershop.eu`, `kiwi.com`, `luxurytraveldmc.com` or `tbohotels.com`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details. Contact sections identified by headings like *Контактное лицо* are filled only with contact information from the booking data. On WizzAir, Hotelston and Itravex the script falls back to common field names and now also completes the contact form when detected. Hotelston pages that include a form with the `booking-info-search-form` id are also supported, automatically filling each traveller block and the contact section.
 
 
 The extension uses placeholder test data that can be modified in `common.js`.

--- a/autofill-extension/manifest.json
+++ b/autofill-extension/manifest.json
@@ -129,7 +129,7 @@
       ],
       "run_at": "document_idle"
     },
-     {
+    {
       "matches": [
         "*://*.goglobal.travel/*"
       ],
@@ -137,6 +137,17 @@
         "lib/jquery.min.js",
         "common.js",
         "goglobal.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": [
+        "*://*.tbohotels.com/*"
+      ],
+      "js": [
+        "lib/jquery.min.js",
+        "common.js",
+        "tbohotels.js"
       ],
       "run_at": "document_idle"
     },

--- a/autofill-extension/tbohotels.js
+++ b/autofill-extension/tbohotels.js
@@ -1,0 +1,51 @@
+(() => {
+  const {
+    passengers,
+    setValue,
+    setDropdown,
+    getContactInfo,
+    createButton
+  } = window.autofillCommon;
+
+  function fillTboHotels(data) {
+    const pax = data && data.passports ? data.passports : passengers;
+    const contact = getContactInfo(data || {});
+
+    pax.forEach((p, idx) => {
+      const first = document.getElementById(`fName_${idx}`);
+      const last = document.getElementById(`lName_${idx}`);
+      const title = document.querySelector(`select[name='title_${idx}']`);
+      setValue(first, p.first_name || p.firstName);
+      setValue(last, p.last_name || p.lastName);
+      if (title) {
+        const t = p.gender === 'FEMALE' ? 'Ms' : 'Mr';
+        setDropdown(title, t);
+      }
+    });
+
+    setValue(document.getElementById('guestEmail'), contact.email);
+    setValue(document.getElementById('guestPhoneNo'), contact.phone);
+    const cc = document.getElementById('guestcountrycode');
+    if (cc && contact.phone) {
+      const m = ('' + contact.phone).match(/^\+\d{1,3}/);
+      if (m) setValue(cc, m[0]);
+    }
+
+    setDropdown(document.getElementById('chkInHrs'), '14');
+    setDropdown(document.getElementById('chkInMin'), '00');
+    setDropdown(document.getElementById('chkOutHrs'), '11');
+    setDropdown(document.getElementById('chkOutMin'), '00');
+
+    const save = document.getElementById('saveCustomerName');
+    if (save) {
+      save.checked = true;
+      save.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => createButton(fillTboHotels));
+  } else {
+    createButton(fillTboHotels);
+  }
+})();


### PR DESCRIPTION
## Summary
- add content script to autofill guest details on tbohotels.com
- register tbohotels.com in manifest
- document TBO Hotels support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68adc4ca5b5483299870abc1f93a8b89