### PR TITLE
Add autofill support for mresort.toursupport.ru

### DIFF
--- a/autofill-extension/README.md
+++ b/autofill-extension/README.md
@@ -1,7 +1,7 @@
 # Flight Booker Autofill Chrome Extension
 
 
-This extension adds a floating button to booking pages on **Ryanair**, **WizzAir**, **Hotelston**, **Itravex**, **W2M DMC**, **Chartershop**, **Kiwi.com**, **LuxuryTravelDMC**, **TBO Hotels**, and **smartsys.dyndns.biz**. Clicking the button fills passenger data with test information. Contact details are automatically populated on these sites when a section titled *Контактное лицо* or similar is found.
+This extension adds a floating button to booking pages on **Ryanair**, **WizzAir**, **Hotelston**, **Itravex**, **W2M DMC**, **Chartershop**, **Kiwi.com**, **LuxuryTravelDMC**, **TBO Hotels**, **smartsys.dyndns.biz**, **Joyce Tours**, and **mresort.toursupport.ru**. Clicking the button fills passenger data with test information. Contact details are automatically populated on these sites when a section titled *Контактное лицо* or similar is found.
 
 
 ## Installation
@@ -11,7 +11,7 @@ This extension adds a floating button to booking pages on **Ryanair**, **WizzAir
 
 ## Usage
 
-Visit a booking page on `ryanair.com`, `wizzair.com`, `hotelston.com`, `b2bdirect.itravex.es`, `b2dmc.w2m.travel`, `chartershop.com.ua`, `chartershop.eu`, `kiwi.com`, `luxurytraveldmc.com`, `tbohotels.com` or `smartsys.dyndns.biz`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details. Contact sections identified by headings like *Контактное лицо* are filled only with contact information from the booking data. On WizzAir, Hotelston and Itravex the script falls back to common field names and now also completes the contact form when detected. Hotelston pages that include a form with the `booking-info-search-form` id are also supported, automatically filling each traveller block and the contact section.
+Visit a booking page on `ryanair.com`, `wizzair.com`, `hotelston.com`, `b2bdirect.itravex.es`, `b2dmc.w2m.travel`, `chartershop.com.ua`, `chartershop.eu`, `kiwi.com`, `luxurytraveldmc.com`, `tbohotels.com`, `joyce-tours.com` or `mresort.toursupport.ru`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details. Contact sections identified by headings like *Контактное лицо* are filled only with contact information from the booking data. On WizzAir, Hotelston and Itravex the script falls back to common field names and now also completes the contact form when detected. Hotelston pages that include a form with the `booking-info-search-form` id are also supported, automatically filling each traveller block and the contact section.
 
 
 The extension uses placeholder test data that can be modified in `common.js`.

--- a/autofill-extension/manifest.json
+++ b/autofill-extension/manifest.json
@@ -176,6 +176,17 @@
     },
     {
       "matches": [
+        "*://mresort.toursupport.ru/*"
+      ],
+      "js": [
+        "lib/jquery.min.js",
+        "common.js",
+        "mresort.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": [
         "<all_urls>"
       ],
       "exclude_matches": [
@@ -187,7 +198,8 @@
         "*://*.chartershop.eu/*",
         "*://*.luxurytraveldmc.com/*",
         "*://*.joyce-tours.com/*",
-        "*://smartsys.dyndns.biz/*"
+        "*://smartsys.dyndns.biz/*",
+        "*://mresort.toursupport.ru/*"
       ],
       "js": [
         "lib/jquery.min.js",

--- a/autofill-extension/mresort.js
+++ b/autofill-extension/mresort.js
@@ -1,0 +1,58 @@
+(() => {
+  const {
+    passengers,
+    setValue,
+    setDropdown,
+    getContactInfo,
+    createButton
+  } = window.autofillCommon;
+
+  function formatDate(value) {
+    if (!value) return '';
+    const datePart = value.split('T')[0].split(' ')[0];
+    let m = datePart.match(/^(\d{4})[-/](\d{2})[-/](\d{2})$/);
+    if (m) return `${m[3]}.${m[2]}.${m[1]}`;
+    m = datePart.match(/^(\d{2})[./-](\d{2})[./-](\d{4})$/);
+    if (m) return `${m[1]}.${m[2]}.${m[3]}`;
+    return datePart;
+  }
+
+  function fillMResort(data) {
+    const pax = data && data.passports ? data.passports : passengers;
+    const contact = getContactInfo(data || {});
+    const blocks = document.querySelectorAll('.tourist-data');
+    blocks.forEach((block, idx) => {
+      const p = pax[idx] || pax[0];
+      setValue(block.querySelector('.samo-tourist-name'), p.first_name || p.firstName);
+      setValue(block.querySelector('.samo-tourist-surname'), p.last_name || p.lastName);
+      const dob = p.birthday || p.dob;
+      setValue(block.querySelector('.samo-born-date'), formatDate(dob));
+      setValue(block.querySelector('.samo-tourist-phone'), p.phone || contact.phone);
+      setValue(block.querySelector('.samo-passport-serie'), p.ps_seria || p.passportSerie || '');
+      setValue(block.querySelector('.samo-passport-number'), p.ps_number || p.passportNumber || '');
+      setDropdown(block.querySelector('.samo-passport-state'), p.citizenship || p.nationality || '13');
+      const genderInputs = block.querySelectorAll('.gender');
+      const gender = (p.gender || p.sex || '').toUpperCase();
+      if (genderInputs.length) {
+        const maleInput = genderInputs[0];
+        const femaleInput = genderInputs[1];
+        const target = gender.startsWith('MR') ? maleInput : femaleInput;
+        if (target) {
+          target.checked = true;
+          target.dispatchEvent(new Event('change', { bubbles: true }));
+          target.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+      }
+    });
+
+    setValue(document.querySelector("input[name='payer[phone]'], input#samo-pay-phone"), contact.phone);
+    setValue(document.querySelector("input[name='payer[email]']"), contact.email);
+    setValue(document.querySelector("input[name='payer[name]']"), `${contact.firstName} ${contact.lastName}`);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => createButton(fillMResort));
+  } else {
+    createButton(fillMResort);
+  }
+})();


### PR DESCRIPTION
## Summary
- add autofill script for mresort.toursupport.ru based on Joyce Tours logic
- include mresort in extension manifest and exclude from generic handler
- document support for Joyce Tours and mresort.toursupport.ru

## Testing
- ⚠️ `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c09dea89b083248da37523f87a6682