### PR TITLE
Add autofill support for book.webbeds.com

### DIFF
--- a/autofill-extension/README.md
+++ b/autofill-extension/README.md
@@ -2,7 +2,7 @@
 
 
 
-This extension adds a floating button to booking pages on **Ryanair**, **WizzAir**, **Hotelston**, **Itravex**, **W2M DMC**, **Chartershop**, **Kiwi.com**, **LuxuryTravelDMC**, **TBO Hotels**, **smartsys.dyndns.biz**, **Joyce Tours**, and **mresort.toursupport.ru**. Clicking the button fills passenger data with test information. Contact details are automatically populated on these sites when a section titled *Контактное лицо* or similar is found.
+This extension adds a floating button to booking pages on **Ryanair**, **WizzAir**, **Hotelston**, **Itravex**, **W2M DMC**, **Chartershop**, **Kiwi.com**, **LuxuryTravelDMC**, **TBO Hotels**, **smartsys.dyndns.biz**, **Joyce Tours**, **mresort.toursupport.ru**, and **book.webbeds.com**. Clicking the button fills passenger data with test information. Contact details are automatically populated on these sites when a section titled *Контактное лицо* or similar is found.
 
 
 
@@ -13,7 +13,7 @@ This extension adds a floating button to booking pages on **Ryanair**, **WizzAir
 
 ## Usage
 
-Visit a booking page on `ryanair.com`, `wizzair.com`, `hotelston.com`, `b2bdirect.itravex.es`, `b2dmc.w2m.travel`, `chartershop.com.ua`, `chartershop.eu`, `kiwi.com`, `luxurytraveldmc.com`, `tbohotels.com`, `joyce-tours.com` or `mresort.toursupport.ru`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details. Contact sections identified by headings like *Контактное лицо* are filled only with contact information from the booking data. On WizzAir, Hotelston and Itravex the script falls back to common field names and now also completes the contact form when detected. Hotelston pages that include a form with the `booking-info-search-form` id are also supported, automatically filling each traveller block and the contact section.
+Visit a booking page on `ryanair.com`, `wizzair.com`, `hotelston.com`, `b2bdirect.itravex.es`, `b2dmc.w2m.travel`, `chartershop.com.ua`, `chartershop.eu`, `kiwi.com`, `luxurytraveldmc.com`, `tbohotels.com`, `joyce-tours.com`, `mresort.toursupport.ru`, or `book.webbeds.com`. A small panel with an **Order ID** field and a **Fill Passenger Info** button will appear in the bottom-right corner of the page. Enter an order number if you have one and press the button. The extension will fetch booking data from `https://cp.gth.com.ua/plugin/getdata?id=<ORDER_ID>` before filling the forms. If no order ID is provided the placeholder test data is used. On Ryanair, the script selects title and gender dropdowns as if a user interacted with them. The script targets the `data-ref` fields for passenger details. Contact sections identified by headings like *Контактное лицо* are filled only with contact information from the booking data. On WizzAir, Hotelston and Itravex the script falls back to common field names and now also completes the contact form when detected. Hotelston pages that include a form with the `booking-info-search-form` id are also supported, automatically filling each traveller block and the contact section.
 
 
 The extension uses placeholder test data that can be modified in `common.js`.

--- a/autofill-extension/manifest.json
+++ b/autofill-extension/manifest.json
@@ -141,6 +141,17 @@
     },
     {
       "matches": [
+        "*://book.webbeds.com/*"
+      ],
+      "js": [
+        "lib/jquery.min.js",
+        "common.js",
+        "webbeds.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": [
         "*://*.tbohotels.com/*"
       ],
       "js": [
@@ -222,6 +233,7 @@
         "*://online.khalidiah.ae/*",
         "*://smartsys.dyndns.biz/*",
         "*://mresort.toursupport.ru/*",
+        "*://book.webbeds.com/*",
         "*://*.drct.aero/*"
       ],
       "js": [

--- a/autofill-extension/webbeds.js
+++ b/autofill-extension/webbeds.js
@@ -1,0 +1,142 @@
+(() => {
+  const {
+    passengers,
+    getContactInfo,
+    setValue,
+    createButton
+  } = window.autofillCommon;
+
+  function toArray(value) {
+    if (Array.isArray(value)) return value;
+    return [value];
+  }
+
+  function pickTitleOptions(passenger) {
+    const type = (passenger?.type || '').toUpperCase();
+    const gender = (passenger?.gender || passenger?.sex || '').toUpperCase();
+    if (type.startsWith('CH')) {
+      return ['Child', 'CHD'];
+    }
+    if (gender.startsWith('F')) {
+      return ['Ms', 'Mrs', 'Miss'];
+    }
+    return ['Mr'];
+  }
+
+  function setMuiSelectValue(trigger, titles) {
+    const optionsList = toArray(titles)
+      .map((t) => (t || '').trim())
+      .filter(Boolean);
+    if (!trigger || !optionsList.length) return;
+
+    const openMenu = () => {
+      trigger.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      trigger.click();
+    };
+
+    const findOption = () => {
+      const listId = trigger.getAttribute('aria-controls');
+      let list = listId ? document.getElementById(listId) : null;
+      if (!list) {
+        list = document.querySelector('ul[role="listbox"]');
+      }
+      if (!list) return null;
+      const candidates = Array.from(
+        list.querySelectorAll('[role="option"], li[role], button[role]')
+      );
+      const normalizedCandidates = candidates.map((el) => ({
+        el,
+        text: (el.textContent || '').trim().toLowerCase()
+      }));
+      for (const desired of optionsList) {
+        const desiredLower = desired.toLowerCase();
+        let match = normalizedCandidates.find((c) => c.text === desiredLower);
+        if (!match) {
+          match = normalizedCandidates.find((c) => c.text.includes(desiredLower));
+        }
+        if (match) {
+          return match.el;
+        }
+      }
+      return normalizedCandidates.length ? normalizedCandidates[0].el : null;
+    };
+
+    const selectOption = () => {
+      const option = findOption();
+      if (!option) return;
+      option.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      option.click();
+      option.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    };
+
+    openMenu();
+    setTimeout(selectOption, 60);
+  }
+
+  function fillGuestRow(row, passenger, delay = 0) {
+    if (!row || !passenger) return;
+    const firstInput = row.querySelector("[data-testid='guest-first-name'] input, input[name$='.firstName']");
+    const lastInput = row.querySelector("[data-testid='guest-last-name'] input, input[name$='.lastName']");
+    const titleTrigger = row.querySelector("[data-testid='title-dropdown'] [role='combobox']");
+
+    if (firstInput) {
+      setValue(firstInput, passenger.first_name || passenger.firstName || '');
+    }
+    if (lastInput) {
+      setValue(lastInput, passenger.last_name || passenger.lastName || '');
+    }
+    if (titleTrigger) {
+      const titles = pickTitleOptions(passenger);
+      setTimeout(() => setMuiSelectValue(titleTrigger, titles), delay);
+    }
+  }
+
+  function fillContact(contact) {
+    if (!contact) return;
+    const firstInput = document.querySelector("input[name='contact.firstName'], input[name='contactFirstName']");
+    const lastInput = document.querySelector("input[name='contact.lastName'], input[name='contactLastName']");
+    const emailInput = document.querySelector(
+      "input[name='contact.email'], input[name='contactEmail'], input[type='email']"
+    );
+    const phoneInput = document.querySelector(
+      "input[name='contact.phone'], input[name='contactPhone'], input[type='tel']"
+    );
+
+    if (firstInput) setValue(firstInput, contact.firstName || '');
+    if (lastInput) setValue(lastInput, contact.lastName || '');
+    if (emailInput) setValue(emailInput, contact.email || '');
+    if (phoneInput) setValue(phoneInput, contact.phone || '');
+  }
+
+  function fillWebbeds(data) {
+    const pax = data?.passports && data.passports.length ? data.passports : passengers;
+    const contact = getContactInfo(data || {});
+    const orderId = data?.order_id || data?.orderId || data?.id || '';
+
+    const agentReferenceInput = document.querySelector("input[name='agentReference']");
+    if (agentReferenceInput) {
+      setValue(agentReferenceInput, orderId || contact.lastName + contact.firstName);
+    }
+
+    const guestRows = document.querySelectorAll("[data-testid='guest-info-row']");
+    guestRows.forEach((row, index) => {
+      const passenger = pax[index] || pax[pax.length - 1] || pax[0];
+      fillGuestRow(row, passenger, index * 120);
+    });
+
+    fillContact(contact);
+
+    const conditionsCheckbox = document.querySelector(
+      "input[name='readConditions'], input[type='checkbox'][name*='conditions']"
+    );
+    if (conditionsCheckbox && !conditionsCheckbox.checked) {
+      conditionsCheckbox.click();
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => createButton(fillWebbeds));
+  } else {
+    createButton(fillWebbeds);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a site-specific content script for book.webbeds.com to populate guest, contact, and agreement fields
- register the script in the extension manifest and document the new supported site

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e307ee1d4c832498ded8ef3a44249d