### PR TITLE
Handle Wizz Air date of birth input

### DIFF
--- a/autofill-extension/wizzair.js
+++ b/autofill-extension/wizzair.js
@@ -26,6 +26,9 @@
         element = sel;
       }
       if (!element) continue;
+      if (element.hasAttribute && element.hasAttribute('readonly')) {
+        element.removeAttribute('readonly');
+      }
       if (element.tagName === 'SELECT') {
         setDropdown(element, value);
       } else {
@@ -128,6 +131,33 @@
         [year],
         idx
       );
+
+      if (day && month && year) {
+        const normalizedDay = day.toString().padStart(2, '0');
+        const normalizedMonth = month.toString().padStart(2, '0');
+        const shortDay = normalizedDay.replace(/^0/, '');
+        const shortMonth = normalizedMonth.replace(/^0/, '');
+        const combinedValues = [
+          `${normalizedDay}.${normalizedMonth}.${year}`,
+          `${shortDay}.${shortMonth}.${year}`,
+          `${year}-${normalizedMonth}-${normalizedDay}`,
+          `${year}-${shortMonth}-${shortDay}`,
+          `${shortDay}/${shortMonth}/${year}`,
+          `${normalizedDay}/${normalizedMonth}/${year}`
+        ];
+        fillFieldWithCandidates(
+          [
+            `#${prefix}`,
+            `[data-test='${prefix}'] input`,
+            `[data-test='${prefix}']`,
+            `input[data-test='${prefix}']`,
+            `input[name$='.${prefix}']`,
+            `input[name$='${prefix}']`
+          ],
+          combinedValues,
+          idx
+        );
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- allow autofill to remove readonly from inputs before setting values
- support combined date-of-birth input formats used in the updated Wizz Air form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e31119d27883248f674e88868f71f5