### PR TITLE
Use runtime messaging for login autofill fetch

### DIFF
--- a/autofill-extension/background.js
+++ b/autofill-extension/background.js
@@ -1,6 +1,6 @@
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === 'fetch' && request.url) {
-    fetch(request.url)
+    fetch(request.url, { credentials: 'include' })
       .then(async (res) => {
         let data = null;
         try {


### PR DESCRIPTION
## Summary
- route login autofill credential requests through the background script via `chrome.runtime.sendMessage`
- reuse background fetch responses to populate credentials while preserving cache logic
- ensure background fetch includes credentials for authenticated requests

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69015288476083248410db4ed50c26ab